### PR TITLE
fix(sidenav): v2 resize behaviour

### DIFF
--- a/examples/layouts.html
+++ b/examples/layouts.html
@@ -70,6 +70,15 @@
           <a href="#" class="sidenav-link">Sublink 2</a>
           <a href="#" class="sidenav-link">Sublink 3</a>
           <a href="#" class="sidenav-link">Sublink 4</a>
+          <a href="#" class="sidenav-link">Sublink 4</a>
+          <a href="#" class="sidenav-link">Sublink 5</a>
+          <a href="#" class="sidenav-link">Sublink 6</a>
+          <a href="#" class="sidenav-link">Sublink 7</a>
+          <a href="#" class="sidenav-link">Sublink 8</a>
+          <a href="#" class="sidenav-link">Sublink 9</a>
+          <a href="#" class="sidenav-link">Sublink 10</a>
+          <a href="#" class="sidenav-link">Sublink 11</a>
+          <a href="#" class="sidenav-link">Sublink 12</a>
         </div>
       </div>
       <a href="#" class="sidenav-link">Link 2</a>

--- a/src/components/sidenav/sidenav.ts
+++ b/src/components/sidenav/sidenav.ts
@@ -34,6 +34,7 @@ export class Sidenav extends AxentixComponent implements Component {
   #overlayElement: HTMLElement;
   #listenerRef: any;
   #windowResizeRef: any;
+  #windowWidth: number;
 
   constructor(element: string, options?: ISidenavOptions, isLoadedWithData?: boolean) {
     super();
@@ -57,6 +58,7 @@ export class Sidenav extends AxentixComponent implements Component {
     this.#sidenavTriggers = document.querySelectorAll('.sidenav-trigger');
     this.#isActive = false;
     this.#isAnimated = false;
+    this.#windowWidth = window.innerWidth;
     this.#isFixed = this.el.classList.contains('sidenav-fixed');
 
     const sidenavFixed = getInstanceByType('Sidenav').find((sidenav) => sidenav.#isFixed);
@@ -86,7 +88,7 @@ export class Sidenav extends AxentixComponent implements Component {
     this.#sidenavTriggers.forEach((trigger) => {
       if (trigger.dataset.target === this.el.id) trigger.addEventListener('click', this.#listenerRef);
     });
-    this.#windowResizeRef = this.close.bind(this);
+    this.#windowResizeRef = this.#resizeHandler.bind(this);
     window.addEventListener('resize', this.#windowResizeRef);
   }
 
@@ -107,6 +109,14 @@ export class Sidenav extends AxentixComponent implements Component {
 
     const index = instances.findIndex((ins) => ins.instance.el.id === this.el.id);
     instances.splice(index, 1);
+  }
+
+  #resizeHandler(e: Event) {
+    const target = e.target as Window;
+    const width = target.innerWidth;
+
+    if (this.#windowWidth !== width) this.close();
+    this.#windowWidth = width;
   }
 
   #cleanLayout() {


### PR DESCRIPTION
## Description

Scrolling in a huge sidenav can close it because of the resize event calling the `close()` method.
This happens because of the searchbar wrapping on specific mobile navigators when scrolling.

## How Has This Been Tested?

Tested on mobile (android & IOS navigators causing the issue).

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] Requires a change to the documentation.