### PR TITLE
fix: material form border width

### DIFF
--- a/src/components/forms/_inputs.scss
+++ b/src/components/forms/_inputs.scss
@@ -130,7 +130,7 @@
   &:not(.form-material-bordered) .form-field:not(.form-default) .form-control {
     border-radius: 0;
   }
-
+  
   .form-field:not(.form-default) {
     padding-top: 0.75rem;
     align-self: start;
@@ -181,6 +181,7 @@
       border-bottom: var(getCssVar(form-material-active-border-width))
         var(getCssVar(form-material-active-border-style)) var(getCssVar(form-material-color));
       transition: width var(getCssVar(form-material-transition-duration)) ease;
+      z-index: var(getCssVar(form-material-after-z-index));
     }
 
     &.form-rtl::after {

--- a/src/components/forms/_inputs.scss
+++ b/src/components/forms/_inputs.scss
@@ -60,7 +60,8 @@
   &.form-invalid {
     #{getCssVar(form-material-color)}: var(getCssVar(form-invalid-color));
     #{getCssVar(form-material-label-color)}: var(getCssVar(form-invalid-color));
-    #{getCssVar(form-material-border)}: var(getCssVar(form-material-active-border-width)) var(getCssVar(form-material-active-border-style)) var(getCssVar(form-invalid-color));
+    #{getCssVar(form-material-border)}: var(getCssVar(form-material-active-border-width))
+      var(getCssVar(form-material-active-border-style)) var(getCssVar(form-invalid-color));
 
     .form-helper-invalid {
       display: block;
@@ -130,7 +131,7 @@
   &:not(.form-material-bordered) .form-field:not(.form-default) .form-control {
     border-radius: 0;
   }
-  
+
   .form-field:not(.form-default) {
     padding-top: 0.75rem;
     align-self: start;

--- a/src/components/forms/_select.scss
+++ b/src/components/forms/_select.scss
@@ -117,7 +117,3 @@ select.form-control:not([multiple]),
 .form-material.form-material-bordered .form-field.is-focused:not(.active) .form-custom-select + label {
   margin-top: 0 !important;
 }
-
-.form-field:not(.form-default)::after {
-  z-index: var(getCssVar(form-material-after-z-index));
-}

--- a/src/components/forms/_select.scss
+++ b/src/components/forms/_select.scss
@@ -117,3 +117,7 @@ select.form-control:not([multiple]),
 .form-material.form-material-bordered .form-field.is-focused:not(.active) .form-custom-select + label {
   margin-top: 0 !important;
 }
+
+.form-field:not(.form-default)::after {
+  z-index: var(getCssVar(form-material-after-z-index));
+}

--- a/src/core/_variables.scss
+++ b/src/core/_variables.scss
@@ -308,6 +308,7 @@ $form-material-border: 2px solid #c7c7c7 !default;
 $form-material-disabled-border: 2px dashed #c7c7c7 !default;
 $form-material-active-border-width: 2px !default;
 $form-material-active-border-style: solid !default;
+$form-material-after-z-index: 15 !default;
 
 $generated-css-vars: map.set($generated-css-vars, 'form-material-color', $form-material-color);
 $generated-css-vars: map.set(
@@ -331,6 +332,11 @@ $generated-css-vars: map.set(
   $generated-css-vars,
   'form-material-active-border-style',
   $form-material-active-border-style
+);
+$generated-css-vars: map.set(
+  $generated-css-vars,
+  'form-material-after-z-index',
+  $form-material-after-z-index
 );
 
 /**

--- a/src/core/_variables.scss
+++ b/src/core/_variables.scss
@@ -304,8 +304,8 @@ $generated-css-vars: map.set($generated-css-vars, 'form-check-disabled-color', $
 $form-material-color: getColor('viride', 'dark', 1) !default;
 $form-material-transition-duration: 0.3s !default;
 $form-material-label-color: getColor('grey', 'dark', 2) !default;
-$form-material-border: 0.08em solid #c7c7c7 !default;
-$form-material-disabled-border: 0.08em dashed #c7c7c7 !default;
+$form-material-border: 0.1em solid #c7c7c7 !default;
+$form-material-disabled-border: 0.1em dashed #c7c7c7 !default;
 $form-material-active-border-width: 0.1em !default;
 $form-material-active-border-style: solid !default;
 

--- a/src/core/_variables.scss
+++ b/src/core/_variables.scss
@@ -304,9 +304,9 @@ $generated-css-vars: map.set($generated-css-vars, 'form-check-disabled-color', $
 $form-material-color: getColor('viride', 'dark', 1) !default;
 $form-material-transition-duration: 0.3s !default;
 $form-material-label-color: getColor('grey', 'dark', 2) !default;
-$form-material-border: 0.1em solid #c7c7c7 !default;
-$form-material-disabled-border: 0.1em dashed #c7c7c7 !default;
-$form-material-active-border-width: 0.1em !default;
+$form-material-border: 2px solid #c7c7c7 !default;
+$form-material-disabled-border: 2px dashed #c7c7c7 !default;
+$form-material-active-border-width: 2px !default;
 $form-material-active-border-style: solid !default;
 
 $generated-css-vars: map.set($generated-css-vars, 'form-material-color', $form-material-color);


### PR DESCRIPTION
## Description

Changed default material border-width to fixed px value, since 0.08 em = 1.28 px
Not rounded px can create different behavior depending on the html element or browser.
This fixes border jump on textareas & create a better behavior on inputs.

The Z index of the after pseudo element needed to be set to make it work with the custom select.
## How Has This Been Tested?

Values tested on docs

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] Requires a change to the documentation.