### PR TITLE
fix: modal & card default padding values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - Uniformize `data` prefixes
   - Code quality
   - Hover effects standardization
+  - Cards & Modals default padding
 - BUGFIXES
 
 # 2.0.0-beta.5 - 2022-01-04

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -34,7 +34,7 @@
 }
 
 .grix {
-  &.vstretch.card {
+  &.vstretch .card {
     align-self: auto;
   }
 

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,27 +1,18 @@
 .card {
   position: relative;
   margin: 0.5rem 0;
-  align-self: start;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 
   .card-header {
     font-size: 1.5rem;
-    padding: 1.5rem;
+    padding: 0.75rem;
   }
 
   .card-content {
-    padding: 1.5rem;
+    padding: 0.75rem;
     flex-grow: 1;
-
-    .card-header {
-      padding: 0 0 3rem 0;
-    }
-
-    .card-footer {
-      padding: 3rem 0 0 0;
-    }
 
     p {
       margin: 0;
@@ -29,7 +20,7 @@
   }
 
   .card-footer {
-    padding: 1.5rem;
+    padding: 0.75rem;
   }
 
   .card-image {
@@ -42,7 +33,12 @@
   }
 }
 
-// Grix stretch fix
-.grix.vstretch .card {
-  align-self: auto;
+.grix {
+  &.vstretch.card {
+    align-self: auto;
+  }
+
+  .card {
+    align-self: start;
+  }
 }

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -26,16 +26,16 @@ $modalTop: getCssVar(modal-top);
   }
 
   .modal-header {
-    padding: 1rem;
+    padding: 0.75rem;
     font-size: 1.5rem;
   }
 
   .modal-content {
-    padding: 1rem;
+    padding: 0.75rem;
   }
 
   .modal-footer {
-    padding: 1rem;
+    padding: 0.75rem;
   }
 
   &.modal-falling {


### PR DESCRIPTION
## Description

Change modal & card default padding values
This fixes the align-self property on cards inside grix

## How Has This Been Tested?

Modal example page on chrome

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] Requires a change to the documentation.