### PR TITLE
feat: active button class

### DIFF
--- a/examples/buttons.html
+++ b/examples/buttons.html
@@ -48,7 +48,7 @@
       <h2>OUTLINE BUTTONS</h2>
       <div class="grix xs3">
         <div class="btn text-primary btn-outline btn-small"><span class="btn-outline-text">DIV</span></div>
-        <a class="btn text-primary btn-outline btn-small"><span class="btn-outline-text">A</span></a>
+        <a class="btn text-primary btn-outline btn-small active"><span class="btn-outline-text">A</span></a>
         <button class="btn text-primary btn-outline btn-small" disabled>
           <span class="btn-outline-text">BTN</span>
         </button>

--- a/examples/buttons.html
+++ b/examples/buttons.html
@@ -14,7 +14,7 @@
 
       <div class="grix xs3">
         <div class="btn primary btn-small hoverable-1">DIV</div>
-        <a href="#" class="btn primary btn-small">A</a>
+        <a href="#" class="btn primary btn-small active">A</a>
         <button class="btn btn-small primary">BTN</button>
 
         <div class="btn primary">DIV</div>

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -24,8 +24,8 @@
     }
   }
 
-  &:hover,
-  &.active {
+  &:hover:not(.btn-outline),
+  &.active:not(.btn-outline) {
     filter: brightness(115%);
   }
 
@@ -141,7 +141,8 @@
       }
     }
 
-    &:hover {
+    &:hover,
+    &.active {
       animation-name: fix-outline-button;
       animation-delay: 0.001s;
       animation-fill-mode: forwards;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,7 +20,7 @@
   &[class*='light-hoverable-'] {
     &:not(.btn-press),
     &:not(.btn-outline) {
-      transition-property: filter, transform, box-shadow;
+      transition-property: filter, transform, box-shadow !important;
     }
   }
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -24,7 +24,8 @@
     }
   }
 
-  &:hover {
+  &:hover,
+  &.active {
     filter: brightness(115%);
   }
 


### PR DESCRIPTION
## Description

Add an active class to the buttons to be able to trigger the filter without hovering.
Fixed the hoverable class on buttons breaking the filter transition.

## How Has This Been Tested?

Example page on chrome

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] Requires a change to the documentation.